### PR TITLE
new "prompt" sub-command for single reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Multi-line prompts can be wrapped into `<<< >>>` blocks.
 
 To end your interaction, hit `Ctrl + D`. Note that the conversation will be lost.
 
+You can also use a single prompt with a simple request-response:
+```
+ask_bedrock prompt "complete this sentence: One small step for me"
+```
+
 ### Pricing
 
 Note that using Ask Amazon Bedrock incurs AWS fees. For more information, see [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/). Consider using a dedicated AWS account and [AWS Budgets](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html) to control costs.

--- a/ask_bedrock/main.py
+++ b/ask_bedrock/main.py
@@ -13,9 +13,8 @@ from langchain.chains.conversation.base import ConversationChain
 from langchain.memory import ConversationBufferMemory
 from langchain_community.chat_models.bedrock import BedrockChat
 
-# quickly ignore deprictaion warnings
+# hide deprication warning in output
 import warnings ; warnings.warn = lambda *args,**kwargs: None
-
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:

--- a/ask_bedrock/main.py
+++ b/ask_bedrock/main.py
@@ -11,10 +11,7 @@ import yaml
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.chains.conversation.base import ConversationChain
 from langchain.memory import ConversationBufferMemory
-from langchain_community.chat_models.bedrock import BedrockChat
-
-# hide deprication warning in output
-import warnings ; warnings.warn = lambda *args,**kwargs: None
+from langchain_aws import ChatBedrock as BedrockChat
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:


### PR DESCRIPTION
*Description of changes:*
This patch adds an new sub command called "prompt" which allows the user to use it like a traditional linux command, i.e. with a single reply.

`~> python ask_bedrock prompt "What's up?"
Hello there! As an AI system, I don't have personal experiences to share, but I'm doing well and ready to assist you with any questions or tasks you may have. How can I help you today?`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
